### PR TITLE
Updates for usage with Pandas 0.20.xx

### DIFF
--- a/Medicare and Medicaid/Medicaid_Benefit_MEPS.ipynb
+++ b/Medicare and Medicaid/Medicaid_Benefit_MEPS.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -33,20 +33,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2902: DtypeWarning: Columns (1322,1403,1436,1522,1605,1620,1621,1627,1636,1687,1737,1744,1747,1748,1756,1759,1765,1772,1775,1776,1779,1782,1793,1807) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  interactivity=interactivity, compiler=compiler, result=result)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# h171.csv is the MEPS 2014 full year consolidated file\n",
     "# available from MEPS website\n",
@@ -55,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -68,24 +59,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:1: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "  if __name__ == '__main__':\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Keep MEPS records with positive medicaid benefits\n",
     "MEPS_medicaid['yes_to_md'] = np.where(MEPS_medicaid.TOTMCD14!=0, 1, 0)\n",
@@ -94,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -108,21 +86,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "# import CPS dataset and keep relevant variables\n",
-    "CPS = pd.read_csv('/Users/Amy/Dropbox/OSPC - Shared/CPS/cpsmar2014t.csv')\n",
+    "CPS = pd.read_csv('../../Dropbox/asec2014_pubuse.csv')\n",
     "medicaid_columns = ['mcaid','peridnum','marsupwt', 'wsal_val', 'a_age', 'a_sex', 'gereg']\n",
     "CPS = CPS[medicaid_columns]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -141,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -152,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -164,29 +142,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "26117"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(CPS)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -198,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -209,29 +176,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/pandas/computation/expressions.py:190: UserWarning: evaluating in Python space because the '*' operator is not supported by numexpr for the bool dtype, use '&' instead\n",
-      "  unsupported[op_str]))\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:36: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame\n",
-      "\n",
-      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:31: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame\n",
-      "\n",
-      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for this_area in Region:\n",
     "    for this_gender in Gender:\n",
@@ -273,29 +223,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "54080496.60000048"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "CPS.marsupwt[CPS.MEPS_ID!=0].sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -307,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -318,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -330,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -342,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -353,8 +292,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -368,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/Medicare and Medicaid/Medicare_Benefit_MEPS.ipynb
+++ b/Medicare and Medicaid/Medicare_Benefit_MEPS.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 61,
    "metadata": {
     "collapsed": true
    },
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 62,
    "metadata": {
     "collapsed": true
    },
@@ -33,20 +33,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 63,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2902: DtypeWarning: Columns (1322,1403,1436,1522,1605,1620,1621,1627,1636,1687,1737,1744,1747,1748,1756,1759,1765,1772,1775,1776,1779,1782,1793,1807) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  interactivity=interactivity, compiler=compiler, result=result)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# h171.csv is the MEPS 2014 full year consolidated file\n",
     "# available from MEPS website\n",
@@ -58,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 64,
    "metadata": {
     "collapsed": false
    },
@@ -67,12 +58,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:1: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:2: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "  if __name__ == '__main__':\n"
+      "  from ipykernel import kernelapp as app\n"
      ]
     }
    ],
@@ -84,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 65,
    "metadata": {
     "collapsed": false
    },
@@ -99,30 +90,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 66,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2902: DtypeWarning: Columns (5,23,24,29,83,265,282) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  interactivity=interactivity, compiler=compiler, result=result)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import CPS\n",
-    "CPS = pd.read_csv('/Users/Amy/Dropbox/OSPC - Shared/CPS/cpsmar2014t.csv')\n",
+    "CPS = pd.read_csv('../../Dropbox/asec2014_pubuse.csv')\n",
     "medicare_columns = ['mcare','peridnum','marsupwt', 'wsal_val', 'a_age', 'a_sex', 'gereg']\n",
     "CPS = CPS[medicare_columns]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 67,
    "metadata": {
     "collapsed": false
    },
@@ -139,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 68,
    "metadata": {
     "collapsed": false
    },
@@ -150,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 69,
    "metadata": {
     "collapsed": true
    },
@@ -162,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 70,
    "metadata": {
     "collapsed": false
    },
@@ -173,7 +155,7 @@
        "18216"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 71,
    "metadata": {
     "collapsed": true
    },
@@ -196,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 72,
    "metadata": {
     "collapsed": true
    },
@@ -207,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 73,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -217,13 +199,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/pandas/computation/expressions.py:190: UserWarning: evaluating in Python space because the '*' operator is not supported by numexpr for the bool dtype, use '&' instead\n",
-      "  unsupported[op_str]))\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:36: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:36: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:31: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:31: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n"
@@ -301,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 74,
    "metadata": {
     "collapsed": false
    },
@@ -312,7 +292,7 @@
        "48956575.720000215"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 75,
    "metadata": {
     "collapsed": false
    },
@@ -335,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 76,
    "metadata": {
     "collapsed": false
    },
@@ -343,10 +323,10 @@
     {
      "data": {
       "text/plain": [
-       "417.8290217250008"
+       "414.00183597926963"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -357,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 77,
    "metadata": {
     "collapsed": true
    },
@@ -369,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 78,
    "metadata": {
     "collapsed": false
    },
@@ -381,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 79,
    "metadata": {
     "collapsed": true
    },
@@ -393,7 +373,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -407,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Benefits and participation for welfare and transfer programs are systematically 
 
 The CPS Transfer Augmentation Model (C-TAM) model adjusts the CPS ASEC for the under-reporting of welfare and transfer program participation and benefits, imputes benefits where they are excluded, and imputes marginal tax rates that stem from welfare and transfer programs. Adjusted welfare and transfer data can serve as the basis for micro-simulating policy reforms (for example, [Basic Income](https://github.com/open-source-economics/Benefits/blob/master/Basic%20Income.pdf)) that replace existing welfare and transfer programs.
 
+Note: when processing the raw CPS files from NBER, use the provided STATA scripts, rather than the SAS scripts.
+
 Currently this Repo includes the following programs<sup>1</sup>, derived from 2014 CPS March Supplement:
 
 - Programs with participation and benefits based on CPS ASEC:

--- a/SNAP/Snap_imputation.ipynb
+++ b/SNAP/Snap_imputation.ipynb
@@ -50,11 +50,20 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2723: DtypeWarning: Columns (5,23,24,29,83,265,282) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  interactivity=interactivity, compiler=compiler, result=result)\n"
+     ]
+    }
+   ],
    "source": [
-    "CPS_dataset = pd.read_csv('C:\\Users\\wangy\\OneDrive\\Documents\\BasicIncomeProject\\SNAP.csv')"
+    "CPS_dataset = pd.read_csv('../../Dropbox/asec2014_pubuse.csv')"
    ]
   },
   {
@@ -273,17 +282,17 @@
       "Dep. Variable:              indicator   R-squared:                       0.121\n",
       "Model:                            OLS   Adj. R-squared:                  0.121\n",
       "Method:                 Least Squares   F-statistic:                     5187.\n",
-      "Date:                Sat, 19 Nov 2016   Prob (F-statistic):               0.00\n",
-      "Time:                        22:07:20   Log-Likelihood:                -13579.\n",
+      "Date:                Wed, 05 Jul 2017   Prob (F-statistic):               0.00\n",
+      "Time:                        10:20:17   Log-Likelihood:                -13579.\n",
       "No. Observations:               37780   AIC:                         2.716e+04\n",
       "Df Residuals:                   37778   BIC:                         2.718e+04\n",
       "Df Model:                           1                                         \n",
       "Covariance Type:            nonrobust                                         \n",
       "==============================================================================\n",
-      "                 coef    std err          t      P>|t|      [95.0% Conf. Int.]\n",
+      "                 coef    std err          t      P>|t|      [0.025      0.975]\n",
       "------------------------------------------------------------------------------\n",
-      "Intercept      0.3364      0.003    112.407      0.000         0.331     0.342\n",
-      "hh_net     -6.732e-06   9.35e-08    -72.019      0.000     -6.92e-06 -6.55e-06\n",
+      "Intercept      0.3364      0.003    112.407      0.000       0.331       0.342\n",
+      "hh_net     -6.732e-06   9.35e-08    -72.019      0.000   -6.92e-06   -6.55e-06\n",
       "==============================================================================\n",
       "Omnibus:                     7958.864   Durbin-Watson:                   1.905\n",
       "Prob(Omnibus):                  0.000   Jarque-Bera (JB):            13983.102\n",
@@ -363,7 +372,7 @@
    "outputs": [],
    "source": [
     "#Import administrative level data\n",
-    "admin = pd.read_csv('C:\\Users\\wangy\\OneDrive\\Documents\\BasicIncomeProject\\Administrative.csv',\n",
+    "admin = pd.read_csv('SNAP_Administrative.csv',\n",
     "                    dtype={ 'Household number': np.float,'Average household benefit': np.float, 'Total': np.float, 'Individual number': np.float})\n",
     "admin.index = admin.Fips"
    ]
@@ -405,7 +414,7 @@
    },
    "outputs": [],
    "source": [
-    "pre_augment_benefit.to_csv('C:\\Users\\wangy\\OneDrive\\Documents\\BasicIncomeProject\\pre-blow-up.csv')"
+    "pre_augment_benefit.to_csv('pre-blow-up.csv')"
    ]
   },
   {
@@ -458,20 +467,20 @@
      "text": [
       "('we need to impute', 193971.92316468252, 'for state', 1)\n",
       "('Method1: regression gives', 194801.16999999993)\n",
-      "('we need to impute', 16953.308549603178, 'for state', 2)\n"
+      "('we need to impute', 16953.308549603178, 'for state', 2)\n",
+      "('Method1: regression gives', 16934.76)\n",
+      "('we need to impute', 121834.77696626983, 'for state', 4)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\wangy\\Anaconda2\\lib\\site-packages\\ipykernel\\__main__.py:20: FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)\n",
-      "C:\\Users\\wangy\\Anaconda2\\lib\\site-packages\\ipykernel\\__main__.py:23: FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)\n",
-      "C:\\Users\\wangy\\Anaconda2\\lib\\site-packages\\ipykernel\\__main__.py:26: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:26: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "C:\\Users\\wangy\\Anaconda2\\lib\\site-packages\\ipykernel\\__main__.py:27: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:27: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n"
@@ -481,10 +490,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('Method1: regression gives', 16934.76)\n",
-      "('we need to impute', 121834.77696626983, 'for state', 4)\n",
       "('Method1: regression gives', 122896.3)\n",
-      "('we need to impute', 69548.836071428552, 'for state', 5)\n",
+      "('we need to impute', 69548.836071428523, 'for state', 5)\n",
       "('Method1: regression gives', 68166.65)\n",
       "('we need to impute', 1054907.1063809535, 'for state', 6)\n",
       "('Method1: regression gives', 1054078.9699999993)\n",
@@ -508,13 +515,13 @@
       "('Method1: regression gives', 589343.48)\n",
       "('we need to impute', 181684.50814880966, 'for state', 18)\n",
       "('Method1: regression gives', 183822.93999999997)\n",
-      "('we need to impute', 80288.963799603196, 'for state', 19)\n",
+      "('we need to impute', 80288.963799603167, 'for state', 19)\n",
       "('Method1: regression gives', 80389.05)\n",
       "('we need to impute', 45866.915066137604, 'for state', 20)\n",
       "('Method1: regression gives', 45311.25)\n",
       "('we need to impute', 158288.98647222226, 'for state', 21)\n",
       "('Method1: regression gives', 158925.84)\n",
-      "('we need to impute', 196241.23023809522, 'for state', 22)\n",
+      "('we need to impute', 196241.23023809519, 'for state', 22)\n",
       "('Method1: regression gives', 199392.33)\n",
       "('we need to impute', 38553.133201479097, 'for state', 23)\n",
       "('Method1: regression gives', 38721.11)\n",
@@ -602,10 +609,10 @@
     "            pool_index = hh_SNAP[this_state&not_imputed&non_current].index\n",
     "            pool = DataFrame({'weight': hh_SNAP.hh_marsupwt[pool_index], 'prob': probs[pool_index]},\n",
     "                            index=pool_index)\n",
-    "            pool = pool.sort(columns='prob', ascending=False)\n",
+    "            pool = pool.sort_values(by='prob', ascending=False)\n",
     "            pool['cumsum_weight'] = pool['weight'].cumsum()\n",
     "            pool['distance'] = abs(pool.cumsum_weight-d['Difference in Population'][FIPS])\n",
-    "            min_index = pool.sort(columns='distance')[:1].index\n",
+    "            min_index = pool.sort_values(by='distance')[:1].index\n",
     "            min_weight = int(pool.loc[min_index].cumsum_weight)\n",
     "            pool['impute'] = np.where(pool.cumsum_weight<=min_weight+10 , 1, 0)\n",
     "            hh_SNAP.impute[pool.index[pool['impute']==1]] = 1\n",
@@ -719,9 +726,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -733,7 +740,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/SS/Augmentation/ss_impute.py
+++ b/SS/Augmentation/ss_impute.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import pandas as pd
 import numpy as np
 import csv
@@ -34,7 +35,7 @@ AveBen2014_MonthlySSA = 70703666667
 
 def read_data():
 
-	cps_alldata = pd.read_csv("cpsmar2014t.csv", header=0, \
+	cps_alldata = pd.read_csv("../../../Dropbox/asec2014_pubuse.csv", header=0, \
 							usecols=["peridnum","gestcen", "gestfips", "marsupwt", "ss_yn", "sskidyn", "ss_val", "dis_hp", "a_maritl", "a_age", "a_hga"])
 	cps_alldata.rename(columns = {'gestcen':'State'}, inplace = True)
 
@@ -117,7 +118,7 @@ def impute(cps_alldata, ssa_data):
 
 
 	#Gets nonrecipients and sorts them by state and likelihood of getting ss
-	nonrecipients = (cps_trimmed[cps_trimmed["ss_yn"] != "Yes"]).sort(columns=['State', 'Prob_Received'], ascending=[True,False])
+	nonrecipients = (cps_trimmed[cps_trimmed["ss_yn"] != "Yes"]).sort_values(by=['State', 'Prob_Received'], ascending=[True,False])
 
 
 	#Converting to monthly values and summing across states
@@ -184,11 +185,11 @@ def impute(cps_alldata, ssa_data):
 	#Combining the imputed recipients with cps recipients
 	imputed_combined = cps_recipients.append(imputed)
 	imputed_combined = imputed_combined.append(nonimputed)
-	imputed_combined.sort(inplace=True)
+	imputed_combined = imputed_combined.sort_values(by='Prob_Received')
 
 	#Getting final results and exporting to csv
 	imputed_grouped = imputed_combined.groupby('State').sum()
-	combined_data.columns = ['CPS_ID','CPS Weighted Recipients', 'CPS Benefit per Recipient', 'Weighted Benefits', 'SSA_Recipients',\
+	combined_data.columns = ['CPS Weighted Recipients', 'CPS Benefit per Recipient', 'Weighted Benefits', 'SSA_Recipients',\
 	 						 'SSA_Benefit', 'Recipients Gap', 'Benefits Gap', 'Ajusted monthly benefit']	
 	combined_data['Imputed Monthly Benefit'] = avemonbensimputed
 	combined_data['CPS + Imputed Recipients'] = imputed_grouped['marsupwt']

--- a/SSI/Imputation/SSI_imputation.ipynb
+++ b/SSI/Imputation/SSI_imputation.ipynb
@@ -46,13 +46,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2902: DtypeWarning: Columns (5,23,24,29,83,265,282) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2723: DtypeWarning: Columns (5,23,24,29,83,265,282) have mixed types. Specify dtype option on import or set low_memory=False.\n",
       "  interactivity=interactivity, compiler=compiler, result=result)\n"
      ]
     }
    ],
    "source": [
-    "CPS_dataset = pd.read_csv('/PATH_TO_CPS/cpsmar2014t.csv')"
+    "CPS_dataset = pd.read_csv('../../../Dropbox/asec2014_pubuse.csv')"
    ]
   },
   {
@@ -78,13 +78,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "CPS_dataset = pd.read_csv('CPSASEC_SSI.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0                         73\n",
+       "1                         72\n",
+       "2                         34\n",
+       "3                          8\n",
+       "4                          2\n",
+       "5                         41\n",
+       "6                         16\n",
+       "7                         43\n",
+       "8                         67\n",
+       "9                         70\n",
+       "10                        66\n",
+       "11                        47\n",
+       "12                        55\n",
+       "13                        38\n",
+       "14                        39\n",
+       "15                         7\n",
+       "16                        39\n",
+       "17                        10\n",
+       "18                        39\n",
+       "19                        17\n",
+       "20        80-84 years of age\n",
+       "21                        67\n",
+       "22                        37\n",
+       "23                        59\n",
+       "24          85+ years of age\n",
+       "25          85+ years of age\n",
+       "26                        48\n",
+       "27                        46\n",
+       "28                        18\n",
+       "29                        16\n",
+       "                 ...        \n",
+       "139385                    50\n",
+       "139386                    58\n",
+       "139387                    39\n",
+       "139388                    34\n",
+       "139389                     3\n",
+       "139390                     1\n",
+       "139391                    26\n",
+       "139392                    26\n",
+       "139393                     2\n",
+       "139394    80-84 years of age\n",
+       "139395                    24\n",
+       "139396                    44\n",
+       "139397                    16\n",
+       "139398                    10\n",
+       "139399                    26\n",
+       "139400                    22\n",
+       "139401                     6\n",
+       "139402                    60\n",
+       "139403                    23\n",
+       "139404                    20\n",
+       "139405                    19\n",
+       "139406                     1\n",
+       "139407                     0\n",
+       "139408                    25\n",
+       "139409                    50\n",
+       "139410                    36\n",
+       "139411                    13\n",
+       "139412                    11\n",
+       "139413                    47\n",
+       "139414                    21\n",
+       "Name: a_age, Length: 139415, dtype: object"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "CPS_dataset.a_age"
    ]
   },
   {
@@ -96,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -113,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -133,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -150,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -173,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -198,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -212,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -229,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -244,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -255,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -267,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -281,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -307,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -329,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -344,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -356,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -367,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -385,13 +468,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "admin = pd.read_csv(\"/Users/Amy/Documents/SSI/SSI_by_age_state.csv\", \n",
+    "admin = pd.read_csv(\"SSI_by_age_state.csv\", \n",
     "                    dtype={'Under 18': np.float, '18-64':np.float, '65 or older': np.float,\n",
     "                           'Under 18 mean': np.float, '18-64 mean':np.float, '65 or older mean': np.float})\n",
     "admin.index = admin.Fips"
@@ -399,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -429,18 +512,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "pre_augment_benefit.to_csv('/Users/Amy/Documents/SSI/pre-blow-up.csv')"
+    "pre_augment_benefit.to_csv('pre-blow-up.csv')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -451,7 +534,7 @@
        "6053051.16999999"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -462,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -503,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {
     "collapsed": true
    },
@@ -515,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -542,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "metadata": {
     "collapsed": true
    },
@@ -554,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -582,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -597,32 +680,36 @@
       "Dep. Variable:          ssi_indicator   No. Observations:               139415\n",
       "Model:                          Logit   Df Residuals:                   139397\n",
       "Method:                           MLE   Df Model:                           17\n",
-      "Date:                Fri, 26 May 2017   Pseudo R-squ.:                  0.6772\n",
-      "Time:                        10:16:41   Log-Likelihood:                -4155.3\n",
+      "Date:                Wed, 05 Jul 2017   Pseudo R-squ.:                  0.6772\n",
+      "Time:                        10:21:20   Log-Likelihood:                -4155.3\n",
       "converged:                       True   LL-Null:                       -12873.\n",
       "                                        LLR p-value:                     0.000\n",
       "=======================================================================================\n",
-      "                          coef    std err          z      P>|z|      [95.0% Conf. Int.]\n",
+      "                          coef    std err          z      P>|z|      [0.025      0.975]\n",
       "---------------------------------------------------------------------------------------\n",
-      "intercept              -9.1377      0.184    -49.634      0.000        -9.499    -8.777\n",
-      "countable_income    -4.355e-05    7.8e-06     -5.583      0.000     -5.88e-05 -2.83e-05\n",
-      "combined_disability     5.3380      0.164     32.460      0.000         5.016     5.660\n",
-      "uc_yn                  -0.7786      0.244     -3.193      0.001        -1.257    -0.301\n",
-      "ss_yn                  -1.6194      0.076    -21.382      0.000        -1.768    -1.471\n",
-      "wc_yn                  -2.1539      0.489     -4.408      0.000        -3.111    -1.196\n",
-      "paw_yn                 -0.4005      0.134     -2.994      0.003        -0.663    -0.138\n",
-      "vet_yn                 -1.1384      0.275     -4.132      0.000        -1.678    -0.598\n",
-      "sur_yn                 -0.7834      0.303     -2.590      0.010        -1.376    -0.191\n",
-      "hed_yn                 -0.3711      0.127     -2.932      0.003        -0.619    -0.123\n",
-      "hcsp_yn                 0.0788      0.120      0.656      0.512        -0.157     0.314\n",
-      "hfdval                  0.3016      0.059      5.078      0.000         0.185     0.418\n",
-      "mcare                   0.6082      0.085      7.179      0.000         0.442     0.774\n",
-      "mcaid                   4.1083      0.094     43.480      0.000         3.923     4.293\n",
-      "age_dummy18            -1.2735      0.244     -5.228      0.000        -1.751    -0.796\n",
-      "age_dummy65             3.3369      0.212     15.708      0.000         2.921     3.753\n",
-      "age18_X_disability      1.2371      0.275      4.493      0.000         0.697     1.777\n",
-      "age65_X_disability     -2.8653      0.216    -13.267      0.000        -3.289    -2.442\n",
-      "=======================================================================================\n"
+      "intercept              -9.1377      0.184    -49.634      0.000      -9.499      -8.777\n",
+      "countable_income    -4.355e-05    7.8e-06     -5.583      0.000   -5.88e-05   -2.83e-05\n",
+      "combined_disability     5.3380      0.164     32.460      0.000       5.016       5.660\n",
+      "uc_yn                  -0.7786      0.244     -3.193      0.001      -1.257      -0.301\n",
+      "ss_yn                  -1.6194      0.076    -21.382      0.000      -1.768      -1.471\n",
+      "wc_yn                  -2.1539      0.489     -4.408      0.000      -3.111      -1.196\n",
+      "paw_yn                 -0.4005      0.134     -2.994      0.003      -0.663      -0.138\n",
+      "vet_yn                 -1.1384      0.275     -4.132      0.000      -1.678      -0.598\n",
+      "sur_yn                 -0.7834      0.303     -2.590      0.010      -1.376      -0.191\n",
+      "hed_yn                 -0.3711      0.127     -2.932      0.003      -0.619      -0.123\n",
+      "hcsp_yn                 0.0788      0.120      0.656      0.512      -0.157       0.314\n",
+      "hfdval                  0.3016      0.059      5.078      0.000       0.185       0.418\n",
+      "mcare                   0.6082      0.085      7.179      0.000       0.442       0.774\n",
+      "mcaid                   4.1083      0.094     43.480      0.000       3.923       4.293\n",
+      "age_dummy18            -1.2735      0.244     -5.228      0.000      -1.751      -0.796\n",
+      "age_dummy65             3.3369      0.212     15.708      0.000       2.921       3.753\n",
+      "age18_X_disability      1.2371      0.275      4.493      0.000       0.697       1.777\n",
+      "age65_X_disability     -2.8653      0.216    -13.267      0.000      -3.289      -2.442\n",
+      "=======================================================================================\n",
+      "\n",
+      "Possibly complete quasi-separation: A fraction 0.58 of observations can be\n",
+      "perfectly predicted. This might indicate that there is complete\n",
+      "quasi-separation. In this case some parameters will not be identified.\n"
      ]
     }
    ],
@@ -632,18 +719,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "probs = results.predict()"
+    "probs = results.predict()\n",
+    "CPS_dataset['probs'] = probs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -831,7 +919,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false
    },
@@ -876,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {
     "collapsed": false
    },
@@ -887,35 +975,13 @@
        "59584999999.99996"
       ]
      },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(CPS_dataset.marsupwt * CPS_dataset.ssi_impute)[CPS_dataset.ssi_participation!=0].sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "9354911.669999978"
-      ]
-     },
      "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "CPS_dataset.marsupwt[CPS_dataset.ssi_participation!=0].sum()"
+    "(CPS_dataset.marsupwt * CPS_dataset.ssi_impute)[CPS_dataset.ssi_participation!=0].sum()"
    ]
   },
   {
@@ -928,10 +994,32 @@
     {
      "data": {
       "text/plain": [
-       "5783271.0799999945"
+       "9354911.669999978"
       ]
      },
      "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "CPS_dataset.marsupwt[CPS_dataset.ssi_participation!=0].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5783271.0799999945"
+      ]
+     },
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -942,21 +1030,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "CPS_dataset.to_csv('SSI_Imputation.csv', \n",
-    "                   columns=['peridnum', 'ssi_participation', 'ssi_impute', 'h_seq', 'wage', 'a_age', 'fwsval','marsupwt'],\n",
+    "                   columns=['peridnum', 'ssi_participation', 'ssi_impute', 'h_seq', 'wage', 'a_age', 'fwsval','marsupwt', 'probs'],\n",
     "                   index=False)"
    ]
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -970,7 +1059,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/VB/VB_imputation.ipynb
+++ b/VB/VB_imputation.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -38,13 +38,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2723: DtypeWarning: Columns (5,23,24,29,83,265,282) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  interactivity=interactivity, compiler=compiler, result=result)\n"
+     ]
+    }
+   ],
    "source": [
-    "CPS_dataset = pd.read_csv('PATH_TO_RAW_CPS/cpsmar2014t.csv')\n",
+    "CPS_dataset = pd.read_csv('../../Dropbox/asec2014_pubuse.csv')\n",
     "columns_to_keep = ['hvet_yn','hvetval','fvetval','finc_vet','sur_yn','srvs_val','sur_sc1','sur_val1','tsurval1','sur_sc2',\n",
     "                   'sur_val2','tsurval2','vet_val','vet_yn','vet_typ1','vet_typ2','vet_typ3','vet_typ4','vet_typ5','hsur_yn',\n",
     "                   'hsurval','fsurval','finc_sur','gestfips','marsupwt','peafever','champ','a_age','wsal_val','semp_val','frse_val',\n",
@@ -56,18 +65,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "CPS_dataset = pd.read_csv('C:\\Users\\wangy\\OneDrive\\Documents\\BasicIncomeProject\\VB information\\data\\VB.csv')"
+    "CPS_dataset = pd.read_csv('VB.csv')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -83,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -95,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -111,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -127,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -143,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -161,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -173,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -196,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -209,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -230,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -258,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -268,7 +277,7 @@
      "output_type": "stream",
      "text": [
       "Optimization terminated successfully.\n",
-      "         Current function value: 0.037504\n",
+      "         Current function value: 0.037499\n",
       "         Iterations 10\n"
      ]
     }
@@ -283,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -294,7 +303,7 @@
        "3517346.2599999965"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -319,34 +328,34 @@
       "Dep. Variable:              indicator   No. Observations:               139415\n",
       "Model:                          Logit   Df Residuals:                   139394\n",
       "Method:                           MLE   Df Model:                           20\n",
-      "Date:                Mon, 15 May 2017   Pseudo R-squ.:                  0.3441\n",
-      "Time:                        16:55:02   Log-Likelihood:                -5228.6\n",
+      "Date:                Wed, 05 Jul 2017   Pseudo R-squ.:                  0.3442\n",
+      "Time:                        10:26:49   Log-Likelihood:                -5227.9\n",
       "converged:                       True   LL-Null:                       -7971.7\n",
       "                                        LLR p-value:                     0.000\n",
       "==============================================================================\n",
-      "                 coef    std err          z      P>|z|      [95.0% Conf. Int.]\n",
+      "                 coef    std err          z      P>|z|      [0.025      0.975]\n",
       "------------------------------------------------------------------------------\n",
-      "a_age          0.0076      0.002      3.288      0.001         0.003     0.012\n",
-      "sex           -0.1342      0.086     -1.565      0.118        -0.302     0.034\n",
-      "income     -6.324e-07   6.68e-07     -0.946      0.344     -1.94e-06  6.78e-07\n",
-      "d1            -0.0197      0.170     -0.116      0.908        -0.354     0.314\n",
-      "d2             0.3553      0.097      3.678      0.000         0.166     0.545\n",
-      "d3            -0.0995      0.170     -0.585      0.558        -0.433     0.234\n",
-      "d4            -0.0693      0.146     -0.475      0.635        -0.355     0.216\n",
-      "d5             0.6409      0.095      6.726      0.000         0.454     0.828\n",
-      "d6             0.3919      0.124      3.168      0.002         0.149     0.634\n",
-      "active         3.8395      0.084     45.710      0.000         3.675     4.004\n",
-      "paw_yn         0.2986      0.532      0.561      0.575        -0.745     1.342\n",
-      "wc_yn          0.9227      0.269      3.432      0.001         0.396     1.450\n",
-      "ss_yn          0.6313      0.115      5.484      0.000         0.406     0.857\n",
-      "uc_yn          0.0617      0.181      0.341      0.733        -0.293     0.416\n",
-      "sur_yn         0.7058      0.201      3.513      0.000         0.312     1.100\n",
-      "hed_yn         0.6809      0.105      6.463      0.000         0.474     0.887\n",
-      "hcsp_yn       -0.1412      0.173     -0.815      0.415        -0.481     0.198\n",
-      "hfdval        -0.2444      0.124     -1.972      0.049        -0.487    -0.001\n",
-      "mcaid         -0.4446      0.135     -3.301      0.001        -0.709    -0.181\n",
-      "mcare         -0.4567      0.121     -3.789      0.000        -0.693    -0.220\n",
-      "intercept     -6.3380      0.117    -54.186      0.000        -6.567    -6.109\n",
+      "a_age          0.0083      0.002      3.501      0.000       0.004       0.013\n",
+      "sex           -0.1346      0.086     -1.568      0.117      -0.303       0.034\n",
+      "income     -6.558e-07    6.7e-07     -0.978      0.328   -1.97e-06    6.58e-07\n",
+      "d1            -0.0194      0.170     -0.114      0.909      -0.353       0.314\n",
+      "d2             0.3551      0.097      3.678      0.000       0.166       0.544\n",
+      "d3            -0.0998      0.170     -0.587      0.557      -0.433       0.233\n",
+      "d4            -0.0673      0.146     -0.462      0.644      -0.353       0.218\n",
+      "d5             0.6402      0.095      6.723      0.000       0.454       0.827\n",
+      "d6             0.3930      0.124      3.177      0.001       0.151       0.635\n",
+      "active         3.8318      0.084     45.564      0.000       3.667       3.997\n",
+      "paw_yn         0.2974      0.532      0.559      0.576      -0.746       1.341\n",
+      "wc_yn          0.9216      0.269      3.429      0.001       0.395       1.448\n",
+      "ss_yn          0.6252      0.115      5.434      0.000       0.400       0.851\n",
+      "uc_yn          0.0605      0.181      0.335      0.738      -0.294       0.415\n",
+      "sur_yn         0.7038      0.201      3.505      0.000       0.310       1.097\n",
+      "hed_yn         0.6845      0.105      6.494      0.000       0.478       0.891\n",
+      "hcsp_yn       -0.1381      0.173     -0.797      0.425      -0.478       0.201\n",
+      "hfdval        -0.2441      0.124     -1.969      0.049      -0.487      -0.001\n",
+      "mcaid         -0.4411      0.135     -3.275      0.001      -0.705      -0.177\n",
+      "mcare         -0.4661      0.120     -3.870      0.000      -0.702      -0.230\n",
+      "intercept     -6.3620      0.119    -53.614      0.000      -6.595      -6.129\n",
       "==============================================================================\n"
      ]
     }
@@ -357,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -375,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -388,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -414,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -432,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true
    },
@@ -456,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },
@@ -469,22 +478,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('we need to impute', 50892.110000000001, 'for state', 1)\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:20: FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:23: FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:26: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:26: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:27: SettingWithCopyWarning: \n",
+      "/Users/andersonfrailey/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:27: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n"
@@ -494,7 +508,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('we need to impute', 50892.110000000001, 'for state', 1)\n",
       "('Method1: regression gives', 49596.91)\n",
       "('we need to impute', 5614.7399999999998, 'for state', 2)\n",
       "('Method1: regression gives', 5809.25)\n",
@@ -505,15 +518,15 @@
       "('we need to impute', 127801.64999999997, 'for state', 6)\n",
       "('Method1: regression gives', 127886.86)\n",
       "('we need to impute', 59113.790000000008, 'for state', 8)\n",
-      "('Method1: regression gives', 57854.21000000001)\n",
+      "('Method1: regression gives', 60369.78)\n",
       "('we need to impute', 10320.050000000003, 'for state', 9)\n",
       "('Method1: regression gives', 9792.18)\n",
       "('we need to impute', 2905.8199999999997, 'for state', 10)\n",
-      "('Method1: regression gives', 2657.9800000000005)\n",
+      "('Method1: regression gives', 3056.7299999999996)\n",
       "('we need to impute', 2460.0299999999997, 'for state', 11)\n",
       "('Method1: regression gives', 2634.59)\n",
       "('we need to impute', 101702.34999999992, 'for state', 12)\n",
-      "('Method1: regression gives', 101386.65)\n",
+      "('Method1: regression gives', 103789.57999999999)\n",
       "('we need to impute', 29402.470000000001, 'for state', 13)\n",
       "('Method1: regression gives', 30182.390000000003)\n",
       "('we need to impute', 9486.9699999999975, 'for state', 15)\n",
@@ -527,7 +540,7 @@
       "('we need to impute', 7120.7300000000032, 'for state', 19)\n",
       "('Method1: regression gives', 7294.28)\n",
       "('we need to impute', 21508.27, 'for state', 20)\n",
-      "('Method1: regression gives', 21266.63)\n",
+      "('Method1: regression gives', 21285.899999999998)\n",
       "('we need to impute', 23579.459999999992, 'for state', 21)\n",
       "('Method1: regression gives', 22644.83)\n",
       "('we need to impute', 41380.729999999996, 'for state', 22)\n",
@@ -539,7 +552,7 @@
       "('we need to impute', 38146.360000000001, 'for state', 25)\n",
       "('Method1: regression gives', 40724.86)\n",
       "('we need to impute', 7169.3100000000122, 'for state', 26)\n",
-      "('Method1: regression gives', 8494.06)\n",
+      "('Method1: regression gives', 8000.469999999999)\n",
       "('we need to impute', 32742.259999999995, 'for state', 27)\n",
       "('Method1: regression gives', 33090.67)\n",
       "('we need to impute', 22767.23, 'for state', 28)\n",
@@ -582,7 +595,7 @@
       "('we need to impute', 13267.260000000002, 'for state', 49)\n",
       "('Method1: regression gives', 12859.44)\n",
       "('we need to impute', 1716.6400000000003, 'for state', 50)\n",
-      "('Method1: regression gives', 1863.5800000000004)\n",
+      "('Method1: regression gives', 1849.3600000000001)\n",
       "('we need to impute', 76446.059999999983, 'for state', 51)\n",
       "('Method1: regression gives', 77029.02000000002)\n",
       "('we need to impute', 724.23999999996158, 'for state', 53)\n",
@@ -590,7 +603,7 @@
       "('we need to impute', 20038.079999999998, 'for state', 54)\n",
       "('Method1: regression gives', 20825.55)\n",
       "('we need to impute', 29038.940000000002, 'for state', 55)\n",
-      "('Method1: regression gives', 28781.69)\n",
+      "('Method1: regression gives', 28632.210000000003)\n",
       "('we need to impute', 718.78999999999905, 'for state', 56)\n",
       "('Method1: regression gives', 746.13)\n"
      ]
@@ -616,10 +629,10 @@
     "            pool_index = VB[this_state&not_imputed&non_current].index\n",
     "            pool = DataFrame({'weight': VB.marsupwt[pool_index], 'prob': probs[pool_index]},\n",
     "                            index=pool_index)\n",
-    "            pool = pool.sort(columns='prob', ascending=False)\n",
+    "            pool = pool.sort_values(by='prob', ascending=False)\n",
     "            pool['cumsum_weight'] = pool['weight'].cumsum()\n",
     "            pool['distance'] = abs(pool.cumsum_weight-d['Difference in Population'][FIPS])\n",
-    "            min_index = pool.sort(columns='distance')[:1].index\n",
+    "            min_index = pool.sort_values(by='distance')[:1].index\n",
     "            min_weight = int(pool.loc[min_index].cumsum_weight)\n",
     "            pool['impute'] = np.where(pool.cumsum_weight<=min_weight+10 , 1, 0)\n",
     "            VB.impute[pool.index[pool['impute']==1]] = 1\n",
@@ -631,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 25,
    "metadata": {
     "collapsed": true
    },
@@ -680,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 26,
    "metadata": {
     "collapsed": true
    },
@@ -698,7 +711,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 27,
    "metadata": {
     "collapsed": true
    },
@@ -711,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 28,
    "metadata": {
     "collapsed": true
    },
@@ -721,12 +734,21 @@
     "r.columns=['State','Individual average medical care']\n",
     "r.to_csv('medical.csv', index=False)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -740,7 +762,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR contains updates to the imputation notebooks so that they can be run using Pandas 0.20.xx. Most of the changes were simply changing `.sort()` to `.sort_values()`.

I also added a line to the C-TAM README file informing users that they should use the STATA scripts provided by NBER to process the raw CPS data, rather than the SAS scripts. This is after I found the notebooks would often run into errors when using a CPS file that had been processed by the SAS scripts, but none when using a CPS processed with the STATA scripts. The exact cause of this is unknown, but in my opinion we should encourage the use of STATA rather than SAS for those purposes until we get to the bottom of this.

@Amy-Xu @MattHJensen 