### PR TITLE
Make SS_impute.py compatible with 2015 CPS

### DIFF
--- a/SS/Augmentation/statecodes.csv
+++ b/SS/Augmentation/statecodes.csv
@@ -1,0 +1,52 @@
+State,gestcen,gestfips
+Maine,11,23
+New Hampshire,12,33
+Vermont,13,50
+Massachusetts,14,25
+Rhode Island,15,44
+Connecticut,16,9
+New York,21,36
+New Jersey,22,34
+Pennsylvania,23,42
+Ohio,31,39
+Indiana,32,18
+Illinois,33,17
+Michigan,34,26
+Wisconsin,35,55
+Minnesota,41,27
+Iowa,42,19
+Missouri,43,29
+North Dakota,44,38
+South Dakota,45,46
+Nebraska,46,31
+Kansas,47,20
+Delaware,51,10
+Maryland,52,24
+District Of Columbia,53,11
+Virginia,54,51
+West Virginia,55,54
+North Carolina,56,37
+South Carolina,57,45
+Georgia,58,13
+Florida,59,12
+Kentucky,61,21
+Tennessee,62,47
+Alabama,63,1
+Mississippi,64,28
+Arkansas,71,5
+Louisiana,72,22
+Oklahoma,73,40
+Texas,74,48
+Montana,81,30
+Idaho,82,16
+Wyoming,83,56
+Colorado,84,8
+New Mexico,85,35
+Arizona,86,4
+Utah,87,49
+Nevada,88,32
+Washington,91,53
+Oregon,92,41
+California,93,6
+Alaska,94,2
+Hawaii,95,15


### PR DESCRIPTION
The 2015 CPS drops the `gestcen` variable used by C-TAM. This PR adds a few lines of code to `ss_impute.py` and a CSV file with the gestfips and gestcen variables associated with each state to account for this.

@Amy-Xu 