### PR TITLE
Modified TANF imputation for children

### DIFF
--- a/TANF/TANF_imputation.ipynb
+++ b/TANF/TANF_imputation.ipynb
@@ -38,30 +38,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/intern/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py:2717: DtypeWarning: Columns (5,22,23,28,80,187,273) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  interactivity=interactivity, compiler=compiler, result=result)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "CPS_dataset = pd.read_csv('asec2015_pubuse.csv')\n",
     "columns_to_keep = ['paw_val','paw_typ','paw_mon','fpawval','marsupwt','a_age','a_sex','wsal_val','semp_val','frse_val',\n",
     "                  'ss_val','rtm_val','oi_val','oi_off','int_yn','uc_yn', 'uc_val','int_val','ssi_yn','ssikidyn',\n",
-    "                  'hfoodsp','a_famnum','a_maritl','fownu6','fownu18','gestfips','peridnum']\n",
+    "                  'hfoodsp','a_famnum','a_maritl','fownu6','fownu18','gestfips','peridnum', 'h_seq', 'ffpos', 'i_pawtyp',\n",
+    "                 'fpersons']\n",
     "CPS_dataset = CPS_dataset[columns_to_keep]\n",
     "CPS_dataset.to_csv('TANF.csv', columns=columns_to_keep, index=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 27,
    "metadata": {
     "collapsed": true
    },
@@ -72,24 +66,116 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mapping = {'None or not in universe': 0, 'Not in universe': 0, 'None': 0}\n",
+    "CPS_dataset.replace(mapping, inplace=True)\n",
+    "income_var = ['paw_val', 'fpawval', 'wsal_val', 'semp_val', 'frse_val']\n",
+    "CPS_dataset[income_var] = CPS_dataset[income_var].astype(int).values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tanf_fam = CPS_dataset[['h_seq', 'ffpos', 'paw_mon']][(CPS_dataset.paw_typ== 'TANF/AFDC')&(CPS_dataset.a_age>'18')]\n",
+    "tanf_fam.rename(columns={'paw_mon':'paw_mon_child'}, inplace=True)\n",
+    "tanf_fam['tanf_fam'] = np.ones(len(tanf_fam))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "CPS_dataset = CPS_dataset.merge(tanf_fam, on=['h_seq', 'ffpos'], how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "CPS_dataset.loc[(CPS_dataset.tanf_fam==1)&(CPS_dataset.a_age<='18'), 'paw_typ'] = 'TANF/AFDC'\n",
+    "CPS_dataset.paw_mon = np.where(CPS_dataset.paw_typ=='TANF/AFDC', CPS_dataset.paw_mon_child, CPS_dataset.paw_mon)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "# TANF value\n",
-    "tanfvalue = pd.to_numeric(np.where(CPS_dataset.paw_typ== 'TANF/AFDC', CPS_dataset.paw_val, 0))\n",
-    "# Also include small part of other Public Assistance\n",
-    "tanfvalue = pd.to_numeric(np.where(CPS_dataset.paw_typ== 'Both', CPS_dataset.paw_val, tanfvalue))\n",
-    "# TANF indicator\n",
-    "indicator = pd.to_numeric(np.where(CPS_dataset.paw_typ== 'TANF/AFDC', 1, 0))\n",
-    "indicator = pd.to_numeric(np.where(CPS_dataset.paw_typ== 'Both', 1, indicator))"
+    "CPS_dataset['temp_indicator'] = np.where(CPS_dataset.paw_typ=='TANF/AFDC', 1, 0)\n",
+    "num_per_fam = CPS_dataset[['h_seq', 'ffpos', 'temp_indicator']].groupby(['h_seq', 'ffpos'], as_index=False).sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "num_per_fam.rename(columns={'temp_indicator':'num_per_fam'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "CPS_dataset = CPS_dataset.merge(num_per_fam, on=['h_seq', 'ffpos'], how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "CPS_dataset['paw_avg'] = np.divide(CPS_dataset.fpawval, CPS_dataset.num_per_fam + 0.0000001)\n",
+    "CPS_dataset.paw_val = np.where(CPS_dataset.paw_typ=='TANF/AFDC', CPS_dataset.paw_avg, CPS_dataset.paw_val)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# TANF value & indicator\n",
+    "tanfvalue = pd.to_numeric(np.where(CPS_dataset.paw_typ== 'TANF/AFDC', CPS_dataset.paw_val, 0))\n",
+    "indicator = pd.to_numeric(np.where(CPS_dataset.paw_typ== 'TANF/AFDC', 1, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
    "metadata": {
     "collapsed": true
    },
@@ -101,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 46,
    "metadata": {
     "collapsed": true
    },
@@ -109,22 +195,20 @@
    "source": [
     "TANF['indicator'] = indicator\n",
     "TANF['marsupwt'] = CPS_dataset.marsupwt\n",
-    "TANF['tanfvalue'] = tanfvalue\n",
     "TANF['gestfips'] = CPS_dataset.gestfips\n",
     "TANF['peridnum'] = CPS_dataset.peridnum"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 47,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "# Number of month receiving TANF\n",
-    "month = np.where(CPS_dataset.paw_mon == 'Not in universe', 0, CPS_dataset.paw_mon)\n",
-    "month = np.where(CPS_dataset.paw_mon == 'Twelve', 12, month)\n",
+    "month = np.where(CPS_dataset.paw_mon == 'Twelve', 12, CPS_dataset.paw_mon)\n",
     "month = np.where(CPS_dataset.paw_mon == 'One', 1, month)\n",
     "month = pd.to_numeric(month)\n",
     "TANF['month'] = month"
@@ -132,23 +216,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 48,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "# Earned income\n",
-    "wage = pd.to_numeric(np.where(CPS_dataset.wsal_val!= 'None or not in universe', CPS_dataset.wsal_val, 0))\n",
-    "self_employed1 = pd.to_numeric(np.where(CPS_dataset.semp_val!= 'None or not in universe', CPS_dataset.semp_val, 0))\n",
-    "self_employed2 = pd.to_numeric(np.where(CPS_dataset.frse_val!= 'None or not in universe', CPS_dataset.frse_val, 0))\n",
-    "earned = wage + self_employed1 + self_employed2 #individual earned income\n",
-    "TANF['earned'] = earned"
+    "#individual earned income\n",
+    "TANF['earned'] = CPS_dataset.wsal_val + CPS_dataset.semp_val + CPS_dataset.frse_val"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 49,
    "metadata": {
     "collapsed": true
    },
@@ -166,27 +246,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 50,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "# Net Income\n",
-    "TANF['net_income'] = earned + unearned"
+    "TANF['net_income'] = TANF.earned + unearned"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 51,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "# Family TANF value\n",
-    "familyvalue = np.where(CPS_dataset.fpawval != 'None', CPS_dataset.fpawval,0)\n",
-    "TANF['familyvalue'] = familyvalue\n",
+    "TANF['familyvalue'] = CPS_dataset.fpawval\n",
     "familyindicator = np.where(TANF['familyvalue'] != 0, 1,0)\n",
     "familyotherTANFindicator = familyindicator - indicator\n",
     "TANF['indicatorOther'] = familyotherTANFindicator                               "
@@ -194,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 52,
    "metadata": {
     "collapsed": true
    },
@@ -212,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 53,
    "metadata": {
     "collapsed": true
    },
@@ -224,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 54,
    "metadata": {
     "collapsed": true
    },
@@ -241,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 55,
    "metadata": {
     "collapsed": true
    },
@@ -257,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 56,
    "metadata": {
     "collapsed": true
    },
@@ -277,66 +356,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": 57,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Warning: Maximum number of iterations has been exceeded.\n",
-      "         Current function value: 0.019560\n",
-      "         Iterations: 35\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/intern/anaconda/lib/python2.7/site-packages/statsmodels/base/model.py:496: ConvergenceWarning: Maximum Likelihood optimization failed to converge. Check mle_retvals\n",
-      "  \"Check mle_retvals\", ConvergenceWarning)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.031598\n",
+      "         Iterations 12\n",
       "                           Logit Regression Results                           \n",
       "==============================================================================\n",
-      "Dep. Variable:              indicator   No. Observations:               199024\n",
-      "Model:                          Logit   Df Residuals:                   199012\n",
-      "Method:                           MLE   Df Model:                           11\n",
-      "Date:                Fri, 04 Aug 2017   Pseudo R-squ.:                  0.2662\n",
-      "Time:                        16:08:35   Log-Likelihood:                -3892.8\n",
-      "converged:                      False   LL-Null:                       -5305.2\n",
+      "Dep. Variable:              indicator   No. Observations:               199099\n",
+      "Model:                          Logit   Df Residuals:                   199088\n",
+      "Method:                           MLE   Df Model:                           10\n",
+      "Date:                Fri, 08 Sep 2017   Pseudo R-squ.:                  0.2488\n",
+      "Time:                        15:15:05   Log-Likelihood:                -6291.1\n",
+      "converged:                       True   LL-Null:                       -8374.9\n",
       "                                        LLR p-value:                     0.000\n",
       "======================================================================================\n",
-      "                         coef    std err          z      P>|z|      [0.025      0.975]\n",
+      "                         coef    std err          z      P>|z|      [95.0% Conf. Int.]\n",
       "--------------------------------------------------------------------------------------\n",
-      "intercept             -8.6636      0.158    -54.864      0.000      -8.973      -8.354\n",
-      "a_age                  0.0231      0.002     10.547      0.000       0.019       0.027\n",
-      "sex                    1.4234      0.101     14.072      0.000       1.225       1.622\n",
-      "childunder6            0.2783      0.047      5.928      0.000       0.186       0.370\n",
-      "child6to18            -0.0007      0.033     -0.022      0.983      -0.065       0.063\n",
-      "earned              -2.59e-05   3.65e-06     -7.091      0.000   -3.31e-05   -1.87e-05\n",
-      "unearned            -8.42e-05    1.1e-05     -7.663      0.000      -0.000   -6.27e-05\n",
-      "indicatorOther       -29.8815    4.2e+05  -7.12e-05      1.000   -8.22e+05    8.22e+05\n",
-      "unemploy_indicator     1.3689      0.170      8.050      0.000       1.036       1.702\n",
-      "ssi_indicator         -0.1037      0.127     -0.814      0.416      -0.353       0.146\n",
-      "snap_indicator         3.2943      0.102     32.180      0.000       3.094       3.495\n",
-      "marriage               0.8828      0.132      6.689      0.000       0.624       1.142\n",
-      "======================================================================================\n",
-      "\n",
-      "Possibly complete quasi-separation: A fraction 0.14 of observations can be\n",
-      "perfectly predicted. This might indicate that there is complete\n",
-      "quasi-separation. In this case some parameters will not be identified.\n"
+      "intercept             -6.6683      0.102    -65.229      0.000        -6.869    -6.468\n",
+      "a_age                  0.0013      0.002      0.702      0.483        -0.002     0.005\n",
+      "sex                    0.5925      0.060      9.902      0.000         0.475     0.710\n",
+      "childunder6            0.0064      0.036      0.177      0.860        -0.065     0.078\n",
+      "child6to18             0.0692      0.022      3.148      0.002         0.026     0.112\n",
+      "earned             -3.814e-05   3.63e-06    -10.517      0.000     -4.52e-05  -3.1e-05\n",
+      "unearned           -7.009e-05   1.02e-05     -6.884      0.000        -9e-05 -5.01e-05\n",
+      "unemploy_indicator     0.9930      0.168      5.907      0.000         0.663     1.322\n",
+      "ssi_indicator         -0.2299      0.122     -1.891      0.059        -0.468     0.008\n",
+      "snap_indicator         3.2705      0.079     41.350      0.000         3.115     3.425\n",
+      "marriage               0.6802      0.130      5.215      0.000         0.425     0.936\n",
+      "======================================================================================\n"
      ]
     }
    ],
    "source": [
     "TANF['intercept'] = np.ones(len(TANF))\n",
     "model = sm.Logit(endog=TANF.indicator, exog=TANF[['intercept','a_age', 'sex', \n",
-    "                                                  'childunder6','child6to18', 'earned', 'unearned','indicatorOther', \n",
+    "                                                  'childunder6','child6to18', 'earned', 'unearned', \n",
     "                                                  'unemploy_indicator','ssi_indicator','snap_indicator',\n",
     "                                                  'marriage']]).fit()\n",
     "print model.summary()"
@@ -344,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 58,
    "metadata": {
     "collapsed": true
    },
@@ -363,22 +425,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 59,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "admin = pd.read_csv('TANF_Administrative.csv',\n",
+    "admin = pd.read_csv('TANF_Administrative_1.csv',\n",
     "                    dtype = {'Total Annual Benefits': np.float, 'Total Annual Recipient': np.float, 'Average Annual Benefits' : np.float})\n",
     "admin.index = admin.Fips"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 60,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -402,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 61,
    "metadata": {
     "collapsed": true
    },
@@ -420,9 +482,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 62,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -444,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 63,
    "metadata": {
     "collapsed": true
    },
@@ -458,134 +520,128 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": 64,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('we need to impute', 27841.905003333333, 'for state', 1)\n"
+      "('we need to impute', 13800.659170000003, 'for state', 1)\n",
+      "('Method1: regression gives', 14270.02)\n",
+      "('we need to impute', 2623.2450003333333, 'for state', 2)\n",
+      "('Method1: regression gives', 2739.67)\n",
+      "('we need to impute', 20803.223336666666, 'for state', 4)\n",
+      "('Method1: regression gives', 20425.72)\n",
+      "('we need to impute', 6891.2933366666666, 'for state', 5)\n",
+      "('Method1: regression gives', 6209.34)\n",
+      "('we need to impute', 852548.30450000009, 'for state', 6)\n",
+      "('Method1: regression gives', 852447.8)\n",
+      "('we need to impute', 32943.81583, 'for state', 8)\n",
+      "('Method1: regression gives', 32840.06999999999)\n",
+      "('we need to impute', 3989.2816700000003, 'for state', 9)\n",
+      "('Method1: regression gives', 4468.6)\n",
+      "('we need to impute', 8661.8408299999992, 'for state', 10)\n",
+      "('Method1: regression gives', 8632.78)\n",
+      "('we need to impute', 6259.1741699999966, 'for state', 11)\n",
+      "('Method1: regression gives', 6260.3099999999995)\n",
+      "('we need to impute', 15007.385836666683, 'for state', 12)\n",
+      "('Method1: regression gives', 14590.65)\n",
+      "('we need to impute', 665.28916333333837, 'for state', 13)\n",
+      "('Method1: regression gives', 2056.93)\n",
+      "('we need to impute', 21013.420003333333, 'for state', 15)\n",
+      "('Method1: regression gives', 20886.829999999998)\n",
+      "('we need to impute', 1694.5799999999999, 'for state', 16)\n",
+      "('Method1: regression gives', 1713.21)\n",
+      "('we need to impute', 7509.843336666665, 'for state', 17)\n",
+      "('Method1: regression gives', 8111.380000000001)\n",
+      "('we need to impute', 2131.9850033333278, 'for state', 18)\n",
+      "('Method1: regression gives', 2206.13)\n",
+      "('we need to impute', 21364.837496666667, 'for state', 19)\n",
+      "('Method1: regression gives', 21394.51)\n",
+      "('we need to impute', 11367.284166666668, 'for state', 20)\n",
+      "('Method1: regression gives', 11534.08)\n",
+      "('we need to impute', 55000.284170000006, 'for state', 21)\n",
+      "('Method1: regression gives', 56029.75000000001)\n",
+      "('we need to impute', -259.03332999999839, 'for state', 22)\n",
+      "('we need to impute', -286.2450000000008, 'for state', 23)\n",
+      "('we need to impute', 23963.898333333334, 'for state', 24)\n",
+      "('Method1: regression gives', 23318.780000000002)\n",
+      "('we need to impute', 42466.352500000001, 'for state', 25)\n",
+      "('Method1: regression gives', 42124.03)\n",
+      "('we need to impute', 27290.639999999992, 'for state', 26)\n",
+      "('Method1: regression gives', 27447.5)\n",
+      "('we need to impute', -306.72833666666702, 'for state', 27)\n",
+      "('we need to impute', 10560.369169999998, 'for state', 28)\n",
+      "('Method1: regression gives', 10703.57)\n",
+      "('we need to impute', 27678.913329999996, 'for state', 29)\n",
+      "('Method1: regression gives', 27542.85)\n",
+      "('we need to impute', 2412.0366670000003, 'for state', 30)\n",
+      "('Method1: regression gives', 2407.86)\n",
+      "('we need to impute', 3221.2733299999991, 'for state', 31)\n",
+      "('Method1: regression gives', 3046.44)\n",
+      "('we need to impute', 14216.152503333335, 'for state', 32)\n",
+      "('Method1: regression gives', 14219.459999999997)\n",
+      "('we need to impute', 3667.3483333333338, 'for state', 33)\n",
+      "('Method1: regression gives', 3776.29)\n",
+      "('we need to impute', 3187.2508333333317, 'for state', 34)\n",
+      "('Method1: regression gives', 3274.09)\n",
+      "('we need to impute', 26672.07417, 'for state', 35)\n",
+      "('Method1: regression gives', 26666.310000000005)\n",
+      "('we need to impute', 153038.17999999999, 'for state', 36)\n",
+      "('Method1: regression gives', 152491.87999999995)\n",
+      "('we need to impute', 13048.904166666664, 'for state', 37)\n",
+      "('Method1: regression gives', 14949.74)\n",
+      "('we need to impute', 1875.0291663333335, 'for state', 38)\n",
+      "('Method1: regression gives', 1931.8399999999997)\n",
+      "('we need to impute', 62943.56666666668, 'for state', 39)\n",
+      "('Method1: regression gives', 64524.17999999999)\n",
+      "('we need to impute', 11624.940003333331, 'for state', 40)\n",
+      "('Method1: regression gives', 12086.539999999999)\n",
+      "('we need to impute', 31011.292496666658, 'for state', 41)\n",
+      "('Method1: regression gives', 30813.38)\n",
+      "('we need to impute', 92646.052466666661, 'for state', 42)\n",
+      "('Method1: regression gives', 92748.40000000001)\n",
+      "('we need to impute', 6597.287503333333, 'for state', 44)\n",
+      "('Method1: regression gives', 6766.16)\n",
+      "('we need to impute', 6839.1799966666695, 'for state', 45)\n",
+      "('Method1: regression gives', 5851.07)\n",
+      "('we need to impute', 3871.4033329999993, 'for state', 46)\n",
+      "('Method1: regression gives', 3863.8700000000003)\n",
+      "('we need to impute', 35573.582499999975, 'for state', 47)\n",
+      "('Method1: regression gives', 35262.38)\n",
+      "('we need to impute', 4814.4341666666587, 'for state', 48)\n",
+      "('Method1: regression gives', 5095.82)\n",
+      "('we need to impute', 4319.0416669999995, 'for state', 49)\n",
+      "('Method1: regression gives', 3729.6899999999996)\n",
+      "('we need to impute', 2204.7874996666669, 'for state', 50)\n",
+      "('Method1: regression gives', 2054.4)\n",
+      "('we need to impute', 42827.842503333341, 'for state', 51)\n",
+      "('Method1: regression gives', 42751.509999999995)\n",
+      "('we need to impute', 69069.760829999999, 'for state', 53)\n",
+      "('Method1: regression gives', 69194.73999999999)\n",
+      "('we need to impute', 9581.905833333336, 'for state', 54)\n",
+      "('Method1: regression gives', 9040.41)\n",
+      "('we need to impute', 43651.118336666681, 'for state', 55)\n",
+      "('Method1: regression gives', 43401.460000000014)\n",
+      "('we need to impute', 109.88333329999989, 'for state', 56)\n",
+      "('Method1: regression gives', 186.76)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/intern/anaconda/lib/python2.7/site-packages/ipykernel_launcher.py:26: SettingWithCopyWarning: \n",
+      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:27: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
-      "/Users/intern/anaconda/lib/python2.7/site-packages/ipykernel_launcher.py:27: SettingWithCopyWarning: \n",
+      "/Users/Amy/anaconda/lib/python2.7/site-packages/ipykernel/__main__.py:28: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('Method1: regression gives', 28420.43)\n",
-      "('we need to impute', 6262.1575003333328, 'for state', 2)\n",
-      "('Method1: regression gives', 6161.149999999999)\n",
-      "('we need to impute', 21909.155003333333, 'for state', 4)\n",
-      "('Method1: regression gives', 21613.53)\n",
-      "('we need to impute', 9437.1158366666659, 'for state', 5)\n",
-      "('Method1: regression gives', 9539.070000000002)\n",
-      "('we need to impute', 1039643.1120000002, 'for state', 6)\n",
-      "('Method1: regression gives', 1039437.4699999997)\n",
-      "('we need to impute', 37973.335830000004, 'for state', 8)\n",
-      "('Method1: regression gives', 39559.10000000001)\n",
-      "('we need to impute', 16362.730003333332, 'for state', 9)\n",
-      "('Method1: regression gives', 16157.160000000002)\n",
-      "('we need to impute', 10512.781663333333, 'for state', 10)\n",
-      "('Method1: regression gives', 10581.630000000001)\n",
-      "('we need to impute', 11508.409169999999, 'for state', 11)\n",
-      "('Method1: regression gives', 11402.189999999999)\n",
-      "('we need to impute', 51636.105836666669, 'for state', 12)\n",
-      "('Method1: regression gives', 51594.63999999999)\n",
-      "('we need to impute', 10446.215830000001, 'for state', 13)\n",
-      "('Method1: regression gives', 10210.339999999998)\n",
-      "('we need to impute', 21771.741669999999, 'for state', 15)\n",
-      "('Method1: regression gives', 21661.75)\n",
-      "('we need to impute', 1694.5799999999999, 'for state', 16)\n",
-      "('Method1: regression gives', 1713.21)\n",
-      "('we need to impute', 27285.450003333335, 'for state', 17)\n",
-      "('Method1: regression gives', 27035.39)\n",
-      "('we need to impute', 5257.0983366666642, 'for state', 18)\n",
-      "('Method1: regression gives', 6012.280000000001)\n",
-      "('we need to impute', 24009.479996666669, 'for state', 19)\n",
-      "('Method1: regression gives', 23954.460000000003)\n",
-      "('we need to impute', 12542.001666666667, 'for state', 20)\n",
-      "('Method1: regression gives', 11703.51)\n",
-      "('we need to impute', 51754.630836666671, 'for state', 21)\n",
-      "('Method1: regression gives', 52868.689999999995)\n",
-      "('we need to impute', 3919.5250033333323, 'for state', 22)\n",
-      "('Method1: regression gives', 4121.67)\n",
-      "('we need to impute', 5390.3866666666681, 'for state', 23)\n",
-      "('Method1: regression gives', 5275.45)\n",
-      "('we need to impute', 30608.14333333333, 'for state', 24)\n",
-      "('Method1: regression gives', 30336.280000000002)\n",
-      "('we need to impute', 59865.743333333332, 'for state', 25)\n",
-      "('Method1: regression gives', 59365.33)\n",
-      "('we need to impute', 40994.444166666668, 'for state', 26)\n",
-      "('Method1: regression gives', 42637.77)\n",
-      "('we need to impute', 20652.659163333334, 'for state', 27)\n",
-      "('Method1: regression gives', 21471.36)\n",
-      "('we need to impute', 10271.846669999999, 'for state', 28)\n",
-      "('Method1: regression gives', 10542.830000000002)\n",
-      "('we need to impute', 38923.174996666668, 'for state', 29)\n",
-      "('Method1: regression gives', 38940.53999999999)\n",
-      "('we need to impute', 5757.7066670000004, 'for state', 30)\n",
-      "('Method1: regression gives', 5572.509999999999)\n",
-      "('we need to impute', 6552.3366633333326, 'for state', 31)\n",
-      "('Method1: regression gives', 6267.58)\n",
-      "('we need to impute', 21524.740836666664, 'for state', 32)\n",
-      "('Method1: regression gives', 21591.15)\n",
-      "('we need to impute', 4067.1100000000001, 'for state', 33)\n",
-      "('Method1: regression gives', 4217.55)\n",
-      "('we need to impute', 27163.378333333327, 'for state', 34)\n",
-      "('Method1: regression gives', 27322.94)\n",
-      "('we need to impute', 30337.102503333332, 'for state', 35)\n",
-      "('Method1: regression gives', 30395.050000000003)\n",
-      "('we need to impute', 187879.32333333333, 'for state', 36)\n",
-      "('Method1: regression gives', 188122.77999999994)\n",
-      "('we need to impute', 20335.445833333331, 'for state', 37)\n",
-      "('Method1: regression gives', 20329.69)\n",
-      "('we need to impute', 3008.6183329999999, 'for state', 38)\n",
-      "('Method1: regression gives', 2961.34)\n",
-      "('we need to impute', 87519.226666666655, 'for state', 39)\n",
-      "('Method1: regression gives', 88066.92999999998)\n",
-      "('we need to impute', 12785.480003333332, 'for state', 40)\n",
-      "('Method1: regression gives', 13255.85)\n",
-      "('we need to impute', 43418.334163333326, 'for state', 41)\n",
-      "('Method1: regression gives', 43603.7)\n",
-      "('we need to impute', 120149.81830000001, 'for state', 42)\n",
-      "('Method1: regression gives', 121038.55000000002)\n",
-      "('we need to impute', 8298.1975033333329, 'for state', 44)\n",
-      "('Method1: regression gives', 8642.86)\n",
-      "('we need to impute', 9122.0449966666692, 'for state', 45)\n",
-      "('Method1: regression gives', 9597.69)\n",
-      "('we need to impute', 3871.1599996666664, 'for state', 46)\n",
-      "('Method1: regression gives', 3985.06)\n",
-      "('we need to impute', 64026.715833333343, 'for state', 47)\n",
-      "('Method1: regression gives', 63281.37000000001)\n",
-      "('we need to impute', 33591.426666666666, 'for state', 48)\n",
-      "('Method1: regression gives', 33812.92)\n",
-      "('we need to impute', 6545.8116669999999, 'for state', 49)\n",
-      "('Method1: regression gives', 6900.499999999999)\n",
-      "('we need to impute', 3898.347499666666, 'for state', 50)\n",
-      "('Method1: regression gives', 3852.76)\n",
-      "('we need to impute', 45939.962503333343, 'for state', 51)\n",
-      "('Method1: regression gives', 44946.670000000006)\n",
-      "('we need to impute', 84152.40916333333, 'for state', 53)\n",
-      "('Method1: regression gives', 83784.83)\n",
-      "('we need to impute', 13363.235833333332, 'for state', 54)\n",
-      "('Method1: regression gives', 11212.769999999997)\n",
-      "('we need to impute', 54651.902503333338, 'for state', 55)\n",
-      "('Method1: regression gives', 54375.64000000001)\n",
-      "('we need to impute', -20.596666700000014, 'for state', 56)\n"
      ]
     }
    ],
@@ -606,6 +662,7 @@
     "        else:\n",
     "            this_state = (TANF.gestfips==FIPS)\n",
     "            not_imputed = (TANF.impute==0)\n",
+    "            children = (TANF.a_age<=18)\n",
     "            pool_index = TANF[this_state&not_imputed&non_current].index\n",
     "            pool = DataFrame({'weight': TANF.marsupwt[pool_index], 'prob': probs[pool_index]},\n",
     "                            index=pool_index)\n",
@@ -624,7 +681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 65,
    "metadata": {
     "collapsed": true
    },
@@ -666,25 +723,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 69,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
     "TANF.to_csv('TANF_Imputation.csv', \n",
-    "                   columns=['peridnum', 'tanf_participation','tanf_impute', 'marsupwt','month'],\n",
+    "                   columns=['peridnum', 'tanf_participation','tanf_impute', 'tanfvalue'],\n",
     "                   index=False)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -704,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
TANF microdata in CPS was way under-reported for children participants, and possibly over-reported for adults participants. This PR modified to impute children only.